### PR TITLE
Sprint VI - Missing profile image on comments. Issue no longer occurs.

### DIFF
--- a/app/src/main/java/com/zpwit_wsb_gr1_project/adapter/CommentAdapter.java
+++ b/app/src/main/java/com/zpwit_wsb_gr1_project/adapter/CommentAdapter.java
@@ -43,7 +43,7 @@ public class CommentAdapter extends RecyclerView.Adapter<CommentAdapter.CommentH
     public void onBindViewHolder(@NonNull CommentHolder holder, @SuppressLint("RecyclerView") int position) {
 
         Glide.with(context)
-                .load(list.get(position).getProfileImageUrl())
+                .load(list.get(position).getProfileImageUrl()).placeholder(R.drawable.ic_person)
                 .into(holder.profileImage);
 
         holder.nameTv.setText(list.get(position).getName());


### PR DESCRIPTION
I've included a placeholder return when a user doesn't have a profile picture. Similarly works in the rest of the application, here is the code was omitted.